### PR TITLE
Update the NVRAM interface for RTEMS

### DIFF
--- a/modules/libcom/RTEMS/posix/rtems_init.c
+++ b/modules/libcom/RTEMS/posix/rtems_init.c
@@ -990,8 +990,8 @@ POSIX_Init ( void *argument __attribute__((unused)))
     if (epicsRtemsInitPreSetBootConfigFromNVRAM(&rtems_bsdnet_config) != 0)
         delayedPanic("epicsRtemsInitPreSetBootConfigFromNVRAM");
     if (rtems_bsdnet_config.bootp == NULL) {
-        extern void setBootConfigFromNVRAM(void);
-        setBootConfigFromNVRAM();
+        extern int setBootConfigFromNVRAM(char *, size_t);
+        setBootConfigFromNVRAM(NULL, 0);
     }
     if (epicsRtemsInitPostSetBootConfigFromNVRAM(&rtems_bsdnet_config) != 0)
         delayedPanic("epicsRtemsInitPostSetBootConfigFromNVRAM");
@@ -1047,14 +1047,23 @@ POSIX_Init ( void *argument __attribute__((unused)))
     printf("\n***** ifconfig lo0 *****\n");
     rtems_bsd_ifconfig_lo0();
 
-    printf("\n***** add dhcpcd hook *****\n");
-    dhcpDone = epicsEventMustCreate(epicsEventEmpty);
-    rtems_dhcpcd_add_hook(&dhcpcd_hook);
+    /* Check whether global environment static network config exists.
+     * If so, use that, else, fall back to DHCP. */
+    extern int setBootConfigFromNVRAM(char *, size_t);
+    int status = setBootConfigFromNVRAM(rtemsInit_NTP_server_ip,
+                                             sizeof(rtemsInit_NTP_server_ip));
+    bool try_dhcp = status != 0;
 
-    printf("\n***** Start default network dhcpcd *****\n");
-    // if MY_BOOTP???
-    default_network_dhcpcd();
+    if (try_dhcp) {
+        printf("\n***** add dhcpcd hook *****\n");
+        dhcpDone = epicsEventMustCreate(epicsEventEmpty);
+        rtems_dhcpcd_add_hook(&dhcpcd_hook);
 
+        printf("\n***** Start default network dhcpcd *****\n");
+        // if MY_BOOTP???
+        default_network_dhcpcd();
+    }
+    
     /* this seems to be hard coded in the BSP -> Sebastian Huber ? */
     printf("\n--Info (hpj)-- bsd task prio IRQS: %d  -----\n", rtems_bsd_get_task_priority("IRQS"));
     printf("\n--Info (hpj)-- bsd task prio TIME: %d  -----\n", rtems_bsd_get_task_priority("TIME"));

--- a/modules/libcom/RTEMS/posix/rtems_init.c
+++ b/modules/libcom/RTEMS/posix/rtems_init.c
@@ -96,19 +96,31 @@ epicsEventId 	dhcpDone;
 /* these settings are needed by the rtems startup
  * may provide by dhcp/bootp
  * or environments from the "BIOS" like u-boot, motboot etc.
+ * These hardcoded values will be assigned to other variables 
+ * and can be overwritten. They are just initial values.
  */
 char rtemsInit_NTP_server_ip[16] = "";
 char bootp_server_name_init[128] = "1001.1001@10.0.5.1:/epics";
 char bootp_boot_file_name_init[128] = "/epics/myExample/bin/RTEMS-beatnik/myExample.boot";
 char bootp_cmdline_init[128] = "/epics/myExample/iocBoot/iocmyExample/st.cmd";
 
-/* TODO check rtems_bsdnet_bootp_cmdline */
-#ifndef RTEMS_LEGACY_STACK
-struct in_addr rtems_bsdnet_bootp_server_address;
-char *rtems_bsdnet_bootp_server_name = bootp_server_name_init;
-char *rtems_bsdnet_bootp_boot_file_name = bootp_boot_file_name_init;
-char *rtems_bsdnet_bootp_cmdline = bootp_cmdline_init;
-#endif // not LEGACY Stack
+/* These settings are for obtaining environment variables for boot
+ * from NVRAM
+ */
+char *nvram_dhcpena;
+char *nvram_if ;
+char *nvram_ip ;
+char *nvram_netmask ;
+char *nvram_gateway;
+char *nvram_bootserver; /* TFTP/boot server IP, also used as DNS/NTP fallback */
+char *nvram_ntpserver;
+char *nvram_epics_script;
+char *nvram_hostname;
+char *nvram_boot_file_name;
+
+char *rtems_bootp_server_name = bootp_server_name_init;
+char *rtems_bootp_boot_file_name = bootp_boot_file_name_init;
+char *rtems_bootp_cmdline = bootp_cmdline_init;
 
 /*
  * Prototypes for some functions not in header files
@@ -234,7 +246,7 @@ initialize_local_filesystem(char **argv)
     extern char _FlashBase[] __attribute__((weak));
     extern char _FlashSize[]  __attribute__((weak));
 
-    argv[0] = rtems_bsdnet_bootp_boot_file_name;
+    argv[0] = rtems_bootp_boot_file_name;
     if (epicsRtemsMountLocalFilesystem(argv)==0) {
         return 1; /* FS setup successful */
 #ifdef RTEMS_LEGACY_STACK
@@ -336,7 +348,7 @@ initialize_remote_filesystem(char **argv, int hasLocalFilesystem)
                                                 mount_point, strerror(errno));
             *cp = '/';
         }
-        argv[1] = rtems_bsdnet_bootp_cmdline;
+        argv[1] = rtems_bootp_cmdline;
     }
     else if (hasLocalFilesystem) {
         return;
@@ -348,22 +360,22 @@ initialize_remote_filesystem(char **argv, int hasLocalFilesystem)
          * if the pathname does not begin with a '/'.  This allows
          * NFS and TFTP to have a similar view of the remote system.
          */
-        if (rtems_bsdnet_bootp_cmdline[0] == '/')
-            cp = rtems_bsdnet_bootp_cmdline + 1;
+        if (rtems_bootp_cmdline[0] == '/')
+            cp = rtems_bootp_cmdline + 1;
         else
-            cp = rtems_bsdnet_bootp_cmdline;
+            cp = rtems_bootp_cmdline;
         cp = strchr(cp, '/');
         if ((cp == NULL)
-         || ((l = cp - rtems_bsdnet_bootp_cmdline) == 0))
-            LogFatal("\"%s\" is not a valid command pathname.\n", rtems_bsdnet_bootp_cmdline);
+         || ((l = cp - rtems_bootp_cmdline) == 0))
+            LogFatal("\"%s\" is not a valid command pathname.\n", rtems_bootp_cmdline);
         cp = mustMalloc(l + 20, "NFS mount paths");
         server_path = cp;
-        server_name = rtems_bsdnet_bootp_server_name;
-        if (rtems_bsdnet_bootp_cmdline[0] == '/') {
+        server_name = rtems_bootp_server_name;
+        if (rtems_bootp_cmdline[0] == '/') {
             mount_point = server_path;
-            strncpy(mount_point, rtems_bsdnet_bootp_cmdline, l);
+            strncpy(mount_point, rtems_bootp_cmdline, l);
             mount_point[l] = '\0';
-            argv[1] = rtems_bsdnet_bootp_cmdline;
+            argv[1] = rtems_bootp_cmdline;
             /*
              * Its probably common to embed the mount point in the server
              * name so, when this is occurring, don't clobber the mount point
@@ -400,14 +412,14 @@ initialize_remote_filesystem(char **argv, int hasLocalFilesystem)
             }
         }
         else {
-            char *abspath = mustMalloc(strlen(rtems_bsdnet_bootp_cmdline)+2,"Absolute command path");
+            char *abspath = mustMalloc(strlen(rtems_bootp_cmdline)+2,"Absolute command path");
             strcpy(server_path, "/tftpboot/");
             mount_point = server_path + strlen(server_path);
-            strncpy(mount_point, rtems_bsdnet_bootp_cmdline, l);
+            strncpy(mount_point, rtems_bootp_cmdline, l);
             mount_point[l] = '\0';
             mount_point--;
             strcpy(abspath, "/");
-            strcat(abspath, rtems_bsdnet_bootp_cmdline);
+            strcat(abspath, rtems_bootp_cmdline);
             argv[1] = abspath;
         }
     }
@@ -990,8 +1002,8 @@ POSIX_Init ( void *argument __attribute__((unused)))
     if (epicsRtemsInitPreSetBootConfigFromNVRAM(&rtems_bsdnet_config) != 0)
         delayedPanic("epicsRtemsInitPreSetBootConfigFromNVRAM");
     if (rtems_bsdnet_config.bootp == NULL) {
-        extern int setBootConfigFromNVRAM(char *, size_t);
-        setBootConfigFromNVRAM(NULL, 0);
+        extern int setBootConfigFromNVRAM(void);
+        setBootConfigFromNVRAM();
     }
     if (epicsRtemsInitPostSetBootConfigFromNVRAM(&rtems_bsdnet_config) != 0)
         delayedPanic("epicsRtemsInitPostSetBootConfigFromNVRAM");
@@ -1049,12 +1061,22 @@ POSIX_Init ( void *argument __attribute__((unused)))
 
     /* Check whether global environment static network config exists.
      * If so, use that, else, fall back to DHCP. */
-    extern int setBootConfigFromNVRAM(char *, size_t);
-    int status = setBootConfigFromNVRAM(rtemsInit_NTP_server_ip,
-                                             sizeof(rtemsInit_NTP_server_ip));
-    bool try_dhcp = status != 0;
+    extern int setBootConfigFromNVRAM();
+    int status = setBootConfigFromNVRAM();
+    
+    //Update NTP_server_ip
+    if (nvram_ntpserver != NULL){
+      for (int i=0;i<16;i++){
+          if (nvram_ntpserver[i] != '\0'){
+	      rtemsInit_NTP_server_ip[i] = nvram_ntpserver[i];
+	  }
+      }
+    }
+    rtems_bootp_cmdline = nvram_epics_script;
+    rtems_bootp_boot_file_name = nvram_boot_file_name;
+    rtems_bootp_server_name = nvram_bootserver;
 
-    if (try_dhcp) {
+    if (strcmp(nvram_dhcpena, "yes")==0 || status != 0){
         printf("\n***** add dhcpcd hook *****\n");
         dhcpDone = epicsEventMustCreate(epicsEventEmpty);
         rtems_dhcpcd_add_hook(&dhcpcd_hook);
@@ -1062,23 +1084,52 @@ POSIX_Init ( void *argument __attribute__((unused)))
         printf("\n***** Start default network dhcpcd *****\n");
         // if MY_BOOTP???
         default_network_dhcpcd();
+    }else{
+      /*
+       * Configure interface with static IP and optional gateway using libbsd
+       */
+        printf("Configuring ifconfig with ip=%s, netmask=%s, gateway=%s\n",
+               nvram_ip? nvram_ip: "NULL",
+               nvram_netmask? nvram_netmask: "NULL",
+               nvram_gateway? nvram_gateway: "NULL");
+
+        if (nvram_ip && nvram_netmask) {
+            int exit_code;
+            exit_code = rtems_bsd_ifconfig(nvram_if, nvram_ip, nvram_netmask, nvram_gateway);
+	    sleep(5);
+            if (exit_code != 0) {
+                printf("rtems_bsd_ifconfig failed (exit code %d)\n", exit_code);
+                exit(-1);
+            }
+        } else {
+            printf("Failed ifconfig with static IP address and netmask from NVRAM\n");
+            exit(-1);
+        }
+
+        sethostname (nvram_hostname, strlen (nvram_hostname));
     }
-    
+
+    /*
+     * Set NTP server for one-shot time sync
+     */
+
     /* this seems to be hard coded in the BSP -> Sebastian Huber ? */
     printf("\n--Info (hpj)-- bsd task prio IRQS: %d  -----\n", rtems_bsd_get_task_priority("IRQS"));
     printf("\n--Info (hpj)-- bsd task prio TIME: %d  -----\n", rtems_bsd_get_task_priority("TIME"));
 
 
-    // wait for dhcp done ... should be if SYNCDHCP is used
-    epicsEventWaitStatus stat;
-    printf("\n ---- Waiting for DHCP ...\n");
-    stat = epicsEventWaitWithTimeout(dhcpDone, 600); 
-    if (stat == epicsEventOK)
-    	epicsEventDestroy(dhcpDone);
-    else if (stat == epicsEventWaitTimeout)
-        printf("\n ---- DHCP timed out!\n");
-    else
-	printf("\n ---- dhcpDone Event Unknown state %d\n", stat);
+    if (strcmp(nvram_dhcpena, "yes")==0){
+        // wait for dhcp done ... should be if SYNCDHCP is used
+        epicsEventWaitStatus stat;
+        printf("\n ---- Waiting for DHCP ...\n");
+        stat = epicsEventWaitWithTimeout(dhcpDone, 600); 
+        if (stat == epicsEventOK)
+        	epicsEventDestroy(dhcpDone);
+        else if (stat == epicsEventWaitTimeout)
+            printf("\n ---- DHCP timed out!\n");
+        else
+            printf("\n ---- dhcpDone Event Unknown state %d\n", stat);
+    }
 
     const char* ifconfg_args[] = {
         "ifconfig", NULL
@@ -1130,6 +1181,10 @@ POSIX_Init ( void *argument __attribute__((unused)))
     printf("\n***** Network Status  *****\n");
     rtems_netstat(3);
     rtems_bsdnet_synchronize_ntp (0, 0);
+
+    rtems_bootp_server_name = rtems_bsdnet_bootp_server_name;
+    rtems_bootp_boot_file_name = rtems_bsdnet_bootp_boot_file_name;
+    rtems_bootp_cmdline = rtems_bsdnet_bootp_cmdline;
 #endif // not RTEMS_LEGACY_STACK
 
     printf("\n***** Setting up file system *****\n");

--- a/modules/libcom/RTEMS/score/rtems_init.c
+++ b/modules/libcom/RTEMS/score/rtems_init.c
@@ -591,8 +591,8 @@ Init (rtems_task_argument ignored)
     if (epicsRtemsInitPreSetBootConfigFromNVRAM(&rtems_bsdnet_config) != 0)
         delayedPanic("epicsRtemsInitPreSetBootConfigFromNVRAM");
     if (rtems_bsdnet_config.bootp == NULL) {
-        extern void setBootConfigFromNVRAM(void);
-        setBootConfigFromNVRAM();
+        extern int setBootConfigFromNVRAM(char *, size_t);
+        setBootConfigFromNVRAM(NULL, 0);
     }
     if (epicsRtemsInitPostSetBootConfigFromNVRAM(&rtems_bsdnet_config) != 0)
         delayedPanic("epicsRtemsInitPostSetBootConfigFromNVRAM");

--- a/modules/libcom/RTEMS/setBootConfigFromNVRAM.c
+++ b/modules/libcom/RTEMS/setBootConfigFromNVRAM.c
@@ -14,6 +14,11 @@
 #include <unistd.h>
 #ifdef RTEMS_LEGACY_STACK
 #include <rtems/rtems_bsdnet.h>
+#else
+#include <stdio.h>
+#include <net/if.h>
+#include <sysexits.h>
+#include <rtems/bsd/bsd.h>
 #endif
 #include <bsp.h>
 #include <string.h>
@@ -158,12 +163,16 @@ motScriptParm(const char *mot_script_boot, char parm)
     return NULL;
 }
 
-void
-setBootConfigFromNVRAM(void)
+int
+setBootConfigFromNVRAM(char *ntp_server_ip, size_t ntp_server_ip_size)
 {
-    char *cp;
     const char *mot_script_boot;
     volatile char *nvp;
+    char *cp;
+    char *ip_address;
+    char *netmask;
+    char *gateway;
+    char *server_name;  /* TFTP/boot server IP, also used as DNS/NTP fallback */
 
 # if defined(BSP_NVRAM_BASE_ADDR)
     nvp = (volatile char *)(BSP_NVRAM_BASE_ADDR+0x70f8);
@@ -172,12 +181,13 @@ setBootConfigFromNVRAM(void)
     int fd;
     if ((fd = open(BSP_I2C_VPD_EEPROM_DEV_NAME, 0)) < 0) {
         printf("Can't open %s: %s\n", BSP_I2C_VPD_EEPROM_DEV_NAME, strerror(errno));
-        return;
+        return -1;
     }
     lseek(fd, 0x10f8, SEEK_SET);
     if (read(fd, gev_buf, sizeof gev_buf) != sizeof gev_buf) {
         printf("Can't read %s: %s\n", BSP_I2C_VPD_EEPROM_DEV_NAME, strerror(errno));
-        return;
+        close(fd);
+        return -1;
     }
     close(fd);
     nvp = gev_buf;
@@ -185,39 +195,105 @@ setBootConfigFromNVRAM(void)
 #  error "No way to read GEV!"
 # endif
 
-    if (rtems_bsdnet_config.bootp != NULL)
-        return;
     mot_script_boot = gev("mot-script-boot", nvp);
-    if ((rtems_bsdnet_bootp_server_name = gev("mot-/dev/enet0-sipa", nvp)) == NULL)
-        rtems_bsdnet_bootp_server_name = motScriptParm(mot_script_boot, 's');
-    if ((rtems_bsdnet_config.gateway = gev("mot-/dev/enet0-gipa", nvp)) == NULL)
-        rtems_bsdnet_config.gateway = motScriptParm(mot_script_boot, 'g');
-    if  ((rtems_bsdnet_config.ifconfig->ip_netmask = gev("mot-/dev/enet0-snma", nvp)) == NULL)
-        rtems_bsdnet_config.ifconfig->ip_netmask = motScriptParm(mot_script_boot, 'm');
+
+    /*
+     * Read network parameters from NVRAM
+     */
+    if ((ip_address = gev("mot-/dev/enet0-cipa", nvp)) == NULL) {
+        ip_address = motScriptParm(mot_script_boot, 'c');
+    }
+
+    if ((netmask = gev("mot-/dev/enet0-snma", nvp)) == NULL) {
+        netmask = motScriptParm(mot_script_boot, 'm');
+    }
+
+    if ((gateway = gev("mot-/dev/enet0-gipa", nvp)) == NULL) {
+        gateway = motScriptParm(mot_script_boot, 'g');
+    }
+    
+    if ((server_name = gev("mot-/dev/enet0-sipa", nvp)) == NULL) {
+        server_name = motScriptParm(mot_script_boot, 's');
+    }
+
+    /*
+     * Apply network configuration
+     */
+#ifdef RTEMS_LEGACY_STACK
+    if (rtems_bsdnet_config.bootp != NULL)
+        return 0;
+
+    rtems_bsdnet_bootp_server_name = server_name;
+    rtems_bsdnet_config.gateway = gateway;
+    rtems_bsdnet_config.ifconfig->ip_netmask = netmask;
 
     rtems_bsdnet_config.name_server[0] = gev("rtems-dns-server", nvp);
     if (rtems_bsdnet_config.name_server[0] == NULL)
-        rtems_bsdnet_config.name_server[0] = rtems_bsdnet_bootp_server_name;
+        rtems_bsdnet_config.name_server[0] = server_name;
     cp = gev("rtems-dns-domainname", nvp);
     if (cp)
         rtems_bsdnet_config.domainname = cp;
 
-    if ((rtems_bsdnet_config.ifconfig->ip_address = gev("mot-/dev/enet0-cipa", nvp)) == NULL)
-        rtems_bsdnet_config.ifconfig->ip_address = motScriptParm(mot_script_boot, 'c');
+    rtems_bsdnet_config.ifconfig->ip_address = ip_address;
     rtems_bsdnet_config.hostname = gev("rtems-client-name", nvp);
     if (rtems_bsdnet_config.hostname == NULL)
-        rtems_bsdnet_config.hostname = rtems_bsdnet_config.ifconfig->ip_address;
+        rtems_bsdnet_config.hostname = ip_address;
 
     if ((rtems_bsdnet_bootp_boot_file_name = gev("mot-/dev/enet0-file", nvp)) == NULL)
         rtems_bsdnet_bootp_boot_file_name = motScriptParm(mot_script_boot, 'f');
+
+    rtems_bsdnet_config.ntp_server[0] = gev("epics-ntpserver", nvp);
+    if (rtems_bsdnet_config.ntp_server[0] == NULL)
+        rtems_bsdnet_config.ntp_server[0] = server_name;
+#else
+    /*
+     * Configure interface with static IP and optional gateway using libbsd
+     */
+    {
+        char ifnamebuf[IF_NAMESIZE];
+        /* Assumes loopback interface is already brought up on
+         * index 0, and index 1 is the first hardware device. */
+        char *ifname = if_indextoname(1, ifnamebuf);
+        if (ifname == NULL) {
+            printf("No network interface found\n");
+            return -1;
+        }
+        printf("Configuring ifconfig with ip=%s, netmask=%s, gateway=%s\n",
+               ip_address? ip_address: "NULL",
+               netmask? netmask: "NULL",
+               gateway? gateway: "NULL");
+        
+        if (ip_address && netmask) {
+            int exit_code;
+            exit_code = rtems_bsd_ifconfig(ifname, ip_address, netmask, gateway);
+            if (exit_code != EX_OK) {
+                printf("rtems_bsd_ifconfig failed (exit code %d)\n", exit_code);
+                return -1;
+            }
+        } else {
+            printf("Skipping static IP address and netmask from NVRAM\n");
+            return -1;
+        }
+    }
+
+    /*
+     * Set NTP server for one-shot time sync
+     */
+    if (ntp_server_ip != NULL && ntp_server_ip_size > 0) {
+        char *ntp_gev = gev("epics-ntpserver", nvp);
+        if (ntp_gev == NULL)
+            ntp_gev = server_name;
+        if (ntp_gev != NULL)
+            snprintf(ntp_server_ip, ntp_server_ip_size, "%s", ntp_gev);
+    }
+#endif
+
     rtems_bsdnet_bootp_cmdline = gev("epics-script", nvp);
     splitRtemsBsdnetBootpCmdline();
     splitNfsMountPath(gev("epics-nfsmount", nvp));
-    rtems_bsdnet_config.ntp_server[0] = gev("epics-ntpserver", nvp);
-    if (rtems_bsdnet_config.ntp_server[0] == NULL)
-        rtems_bsdnet_config.ntp_server[0] = rtems_bsdnet_bootp_server_name;
     if ((cp = gev("epics-tz", nvp)) != NULL)
         epicsEnvSet("TZ", cp);
+    return 0;
 }
 
 #elif defined(HAVE_PPCBUG)
@@ -254,9 +330,10 @@ static char *addr(char *cbuf, uint32_t addr)
     return (char *)inet_ntop(AF_INET, &a, cbuf, INET_ADDRSTRLEN);
 }
 
-void
-setBootConfigFromNVRAM(void)
+int
+setBootConfigFromNVRAM(char *ntp_server_ip, size_t ntp_server_ip_size)
 {
+#ifdef RTEMS_LEGACY_STACK
     static struct ppcbug_nvram nvram;
     static char ip_address[INET_ADDRSTRLEN];
     static char ip_netmask[INET_ADDRSTRLEN];
@@ -264,7 +341,7 @@ setBootConfigFromNVRAM(void)
     static char gateway[INET_ADDRSTRLEN];
 
     if (rtems_bsdnet_config.bootp != NULL)
-        return;
+        return 0;
 
     /*
      * Get network configuration from PPCBUG.
@@ -318,6 +395,11 @@ setBootConfigFromNVRAM(void)
     rtems_bsdnet_bootp_boot_file_name = nvram.BootFilenameString;
     rtems_bsdnet_bootp_cmdline = nvram.ArgumentFilenameString;
     splitRtemsBsdnetBootpCmdline();
+    return 0;
+#else
+    /* TODO: Implement NVRAM boot configuration for libbsd if needed */
+    return -1;
+#endif
 }
 
 #elif defined(__mcf528x__)
@@ -336,13 +418,14 @@ env(const char *parm, const char *defaultValue)
     return epicsStrDup(cp);
 }
 
-void
-setBootConfigFromNVRAM(void)
+int
+setBootConfigFromNVRAM(char *ntp_server_ip, size_t ntp_server_ip_size)
 {
+#ifdef RTEMS_LEGACY_STACK
     const char *cp1;
 
     if (rtems_bsdnet_config.bootp != NULL)
-        return;
+        return 0;
     rtems_bsdnet_config.gateway = env("GATEWAY", NULL);
     rtems_bsdnet_config.ifconfig->ip_netmask = env("NETMASK", "255.255.252.0");
 
@@ -359,16 +442,22 @@ setBootConfigFromNVRAM(void)
     splitNfsMountPath(env("NFSMOUNT", NULL));
     if ((cp1 = env("TZ", NULL)) != NULL)
         epicsEnvSet("TZ", cp1);
+    return 0;
+#else
+    /* TODO: Implement NVRAM boot configuration for libbsd if needed */
+    return -1;
+#endif
 }
 
 #else
 /*
  * Placeholder for systems without NVRAM
  */
-void
-setBootConfigFromNVRAM(void)
+int
+setBootConfigFromNVRAM(char *ntp_server_ip, size_t ntp_server_ip_size)
 {
     printf("SYSTEM HAS NO NON-VOLATILE RAM!\n");
     printf("YOU MUST USE SOME OTHER METHOD TO OBTAIN NETWORK CONFIGURATION\n");
+    return -1;
 }
 #endif

--- a/modules/libcom/RTEMS/setBootConfigFromNVRAM.c
+++ b/modules/libcom/RTEMS/setBootConfigFromNVRAM.c
@@ -33,7 +33,17 @@ char *env_nfsServer;
 char *env_nfsPath;
 char *env_nfsMountPoint;
 
-extern char* rtems_bsdnet_bootp_cmdline;
+extern char *nvram_dhcpena;
+extern char *nvram_if ;
+extern char *nvram_ip ;
+extern char *nvram_netmask ;
+extern char *nvram_gateway;
+extern char *nvram_bootserver; /* TFTP/boot server IP, also used as DNS/NTP fallback */
+extern char *nvram_ntpserver;
+extern char *nvram_epics_script;
+extern char *nvram_hostname;
+extern char *nvram_boot_file_name;
+
 /*
  * Split argument string of form nfs_server:nfs_export:<path>
  * The nfs_export component will be used as:
@@ -48,11 +58,11 @@ extern char* rtems_bsdnet_bootp_cmdline;
  *       - read commands from st.cmd
  */
 static void
-splitRtemsBsdnetBootpCmdline(void)
+splitRtemsBootpCmdline(char * Cmdline)
 {
     char *cp1, *cp2, *cp3;
 
-    if ((cp1 = rtems_bsdnet_bootp_cmdline) == NULL)
+    if ((cp1 = Cmdline) == NULL)
         return;
     if (((cp2 = strchr(cp1, ':')) != NULL)
      && (((cp3 = strchr(cp2+1, ' ')) != NULL)
@@ -66,7 +76,7 @@ splitRtemsBsdnetBootpCmdline(void)
             env_nfsServer = cp1;
             env_nfsMountPoint = env_nfsPath = epicsStrDup(cp2);
             *cp3 = '/';
-            rtems_bsdnet_bootp_cmdline = cp2;
+            Cmdline = cp2;
         }
     }
 }
@@ -164,15 +174,11 @@ motScriptParm(const char *mot_script_boot, char parm)
 }
 
 int
-setBootConfigFromNVRAM(char *ntp_server_ip, size_t ntp_server_ip_size)
+setBootConfigFromNVRAM()
 {
     const char *mot_script_boot;
     volatile char *nvp;
     char *cp;
-    char *ip_address;
-    char *netmask;
-    char *gateway;
-    char *server_name;  /* TFTP/boot server IP, also used as DNS/NTP fallback */
 
 # if defined(BSP_NVRAM_BASE_ADDR)
     nvp = (volatile char *)(BSP_NVRAM_BASE_ADDR+0x70f8);
@@ -197,102 +203,103 @@ setBootConfigFromNVRAM(char *ntp_server_ip, size_t ntp_server_ip_size)
 
     mot_script_boot = gev("mot-script-boot", nvp);
 
-    /*
-     * Read network parameters from NVRAM
-     */
-    if ((ip_address = gev("mot-/dev/enet0-cipa", nvp)) == NULL) {
-        ip_address = motScriptParm(mot_script_boot, 'c');
-    }
-
-    if ((netmask = gev("mot-/dev/enet0-snma", nvp)) == NULL) {
-        netmask = motScriptParm(mot_script_boot, 'm');
-    }
-
-    if ((gateway = gev("mot-/dev/enet0-gipa", nvp)) == NULL) {
-        gateway = motScriptParm(mot_script_boot, 'g');
-    }
-    
-    if ((server_name = gev("mot-/dev/enet0-sipa", nvp)) == NULL) {
-        server_name = motScriptParm(mot_script_boot, 's');
-    }
-
-    /*
-     * Apply network configuration
-     */
 #ifdef RTEMS_LEGACY_STACK
     if (rtems_bsdnet_config.bootp != NULL)
-        return 0;
+        return -1;
 
-    rtems_bsdnet_bootp_server_name = server_name;
-    rtems_bsdnet_config.gateway = gateway;
-    rtems_bsdnet_config.ifconfig->ip_netmask = netmask;
+    if ((rtems_bsdnet_bootp_server_name = gev("mot-/dev/enet0-sipa", nvp)) == NULL)
+        rtems_bsdnet_bootp_server_name = motScriptParm(mot_script_boot, 's');
+    if ((rtems_bsdnet_config.gateway = gev("mot-/dev/enet0-gipa", nvp)) == NULL)
+        rtems_bsdnet_config.gateway = motScriptParm(mot_script_boot, 'g');
+    if  ((rtems_bsdnet_config.ifconfig->ip_netmask = gev("mot-/dev/enet0-snma", nvp)) == NULL)
+        rtems_bsdnet_config.ifconfig->ip_netmask = motScriptParm(mot_script_boot, 'm');
 
     rtems_bsdnet_config.name_server[0] = gev("rtems-dns-server", nvp);
     if (rtems_bsdnet_config.name_server[0] == NULL)
-        rtems_bsdnet_config.name_server[0] = server_name;
+        rtems_bsdnet_config.name_server[0] = rtems_bsdnet_bootp_server_name;
     cp = gev("rtems-dns-domainname", nvp);
     if (cp)
         rtems_bsdnet_config.domainname = cp;
 
-    rtems_bsdnet_config.ifconfig->ip_address = ip_address;
+    if ((rtems_bsdnet_config.ifconfig->ip_address = gev("mot-/dev/enet0-cipa", nvp)) == NULL)
+        rtems_bsdnet_config.ifconfig->ip_address = motScriptParm(mot_script_boot, 'c');
     rtems_bsdnet_config.hostname = gev("rtems-client-name", nvp);
     if (rtems_bsdnet_config.hostname == NULL)
-        rtems_bsdnet_config.hostname = ip_address;
+        rtems_bsdnet_config.hostname = rtems_bsdnet_config.ifconfig->ip_address;
 
     if ((rtems_bsdnet_bootp_boot_file_name = gev("mot-/dev/enet0-file", nvp)) == NULL)
         rtems_bsdnet_bootp_boot_file_name = motScriptParm(mot_script_boot, 'f');
-
+    rtems_bsdnet_bootp_cmdline = gev("epics-script", nvp);
+    splitRtemsBootpCmdline(rtems_bsdnet_bootp_cmdline);
+    splitNfsMountPath(gev("epics-nfsmount", nvp));
     rtems_bsdnet_config.ntp_server[0] = gev("epics-ntpserver", nvp);
     if (rtems_bsdnet_config.ntp_server[0] == NULL)
-        rtems_bsdnet_config.ntp_server[0] = server_name;
+        rtems_bsdnet_config.ntp_server[0] = rtems_bsdnet_bootp_server_name;
+    if ((cp = gev("epics-tz", nvp)) != NULL)
+        epicsEnvSet("TZ", cp);
 #else
     /*
-     * Configure interface with static IP and optional gateway using libbsd
+     * Read network parameters from NVRAM
      */
-    {
+    if ((nvram_dhcpena = gev("dhcp_ena",nvp)) == NULL){
+        nvram_dhcpena = "yes";
+    }
+
+    if ((nvram_if = gev("bootif",nvp)) == NULL){
         char ifnamebuf[IF_NAMESIZE];
         /* Assumes loopback interface is already brought up on
          * index 0, and index 1 is the first hardware device. */
-        char *ifname = if_indextoname(1, ifnamebuf);
-        if (ifname == NULL) {
+        nvram_if = if_indextoname(1, ifnamebuf);
+        if (nvram_if == NULL) {
             printf("No network interface found\n");
-            return -1;
         }
-        printf("Configuring ifconfig with ip=%s, netmask=%s, gateway=%s\n",
-               ip_address? ip_address: "NULL",
-               netmask? netmask: "NULL",
-               gateway? gateway: "NULL");
-        
-        if (ip_address && netmask) {
-            int exit_code;
-            exit_code = rtems_bsd_ifconfig(ifname, ip_address, netmask, gateway);
-            if (exit_code != EX_OK) {
-                printf("rtems_bsd_ifconfig failed (exit code %d)\n", exit_code);
-                return -1;
-            }
-        } else {
-            printf("Skipping static IP address and netmask from NVRAM\n");
-            return -1;
+    }
+    if ((nvram_ip = gev("ipaddr", nvp)) == NULL) {
+        if ((nvram_ip = gev("mot-/dev/enet0-cipa", nvp)) == NULL) {
+            nvram_ip = motScriptParm(mot_script_boot, 'c');
         }
     }
 
-    /*
-     * Set NTP server for one-shot time sync
-     */
-    if (ntp_server_ip != NULL && ntp_server_ip_size > 0) {
-        char *ntp_gev = gev("epics-ntpserver", nvp);
-        if (ntp_gev == NULL)
-            ntp_gev = server_name;
-        if (ntp_gev != NULL)
-            snprintf(ntp_server_ip, ntp_server_ip_size, "%s", ntp_gev);
+    if ((nvram_netmask = gev("netmask", nvp)) == NULL) {
+        if ((nvram_netmask = gev("mot-/dev/enet0-snma", nvp)) == NULL) {
+            nvram_netmask = motScriptParm(mot_script_boot, 'm');
+        }
     }
-#endif
 
-    rtems_bsdnet_bootp_cmdline = gev("epics-script", nvp);
-    splitRtemsBsdnetBootpCmdline();
+    if ((nvram_gateway = gev("gatewayip", nvp)) == NULL) {
+        if ((nvram_gateway = gev("mot-/dev/enet0-gipa", nvp)) == NULL) {
+            nvram_gateway = motScriptParm(mot_script_boot, 'g');
+        }
+    }
+    
+    if ((nvram_bootserver = gev("bootserverip", nvp)) == NULL) {
+        if ((nvram_bootserver = gev("mot-/dev/enet0-sipa", nvp)) == NULL) {
+            nvram_bootserver = motScriptParm(mot_script_boot, 's');
+        }
+    }
+
+    if ((nvram_boot_file_name = gev("bootfile", nvp)) == NULL) {
+        if ((nvram_boot_file_name = gev("mot-/dev/enet0-file", nvp)) == NULL) {
+            nvram_boot_file_name = motScriptParm(mot_script_boot, 'f');
+	}
+    }
+
+    if ((nvram_ntpserver = gev("epics-ntpserver", nvp)) == NULL) {
+        nvram_ntpserver = nvram_bootserver;
+    }
+
+    nvram_epics_script = gev("epics-script",nvp);
+
+    if ((nvram_hostname = gev("hostname",nvp)) == NULL) {
+        nvram_hostname = gev("rtems-client-name", nvp);
+    }
+
+    splitRtemsBootpCmdline(nvram_epics_script);
     splitNfsMountPath(gev("epics-nfsmount", nvp));
+
     if ((cp = gev("epics-tz", nvp)) != NULL)
         epicsEnvSet("TZ", cp);
+#endif
     return 0;
 }
 
@@ -331,7 +338,7 @@ static char *addr(char *cbuf, uint32_t addr)
 }
 
 int
-setBootConfigFromNVRAM(char *ntp_server_ip, size_t ntp_server_ip_size)
+setBootConfigFromNVRAM()
 {
 #ifdef RTEMS_LEGACY_STACK
     static struct ppcbug_nvram nvram;
@@ -394,7 +401,7 @@ setBootConfigFromNVRAM(char *ntp_server_ip, size_t ntp_server_ip_size)
 
     rtems_bsdnet_bootp_boot_file_name = nvram.BootFilenameString;
     rtems_bsdnet_bootp_cmdline = nvram.ArgumentFilenameString;
-    splitRtemsBsdnetBootpCmdline();
+    splitRtemsBootpCmdline(rtems_bsdnet_bootp_cmdline);
     return 0;
 #else
     /* TODO: Implement NVRAM boot configuration for libbsd if needed */
@@ -419,7 +426,7 @@ env(const char *parm, const char *defaultValue)
 }
 
 int
-setBootConfigFromNVRAM(char *ntp_server_ip, size_t ntp_server_ip_size)
+setBootConfigFromNVRAM()
 {
 #ifdef RTEMS_LEGACY_STACK
     const char *cp1;
@@ -449,12 +456,51 @@ setBootConfigFromNVRAM(char *ntp_server_ip, size_t ntp_server_ip_size)
 #endif
 }
 
+#elif defined(HAS_UBOOT)
+
+int
+setBootConfigFromNVRAM(void){
+    char *cp;
+
+    if ((nvram_dhcpena = bsp_uboot_getenv("dhcp_ena")) == NULL){
+        nvram_dhcpena = "yes";
+    }
+
+    nvram_if = bsp_uboot_getenv("bootif");
+    if ((nvram_if = bsp_uboot_getenv("bootif")) == NULL){
+    	nvram_if = "tsec0";
+    }
+
+    nvram_ip = bsp_uboot_getenv("ipaddr");
+
+    nvram_netmask = bsp_uboot_getenv("netmask");
+
+    nvram_gateway = bsp_uboot_getenv("gatwayip");
+
+    nvram_bootserver = bsp_uboot_getenv("bootserverip");
+
+    nvram_ntpserver = bsp_uboot_getenv("epics-ntpserver");
+
+    nvram_epics_script = bsp_uboot_getenv("epics-script");
+
+    nvram_hostname = bsp_uboot_getenv("hostname");
+
+    nvram_boot_file_name = bsp_uboot_getenv("bootfile");
+
+    splitRtemsBootpCmdline(nvram_epics_script);
+    splitNfsMountPath(bsp_uboot_getenv("epics-nfsmount"));
+    if ((cp = bsp_uboot_getenv("epics-tz")) != NULL)
+        epicsEnvSet("TZ", cp);
+
+    return 0;
+}
+
 #else
 /*
  * Placeholder for systems without NVRAM
  */
 int
-setBootConfigFromNVRAM(char *ntp_server_ip, size_t ntp_server_ip_size)
+setBootConfigFromNVRAM()
 {
     printf("SYSTEM HAS NO NON-VOLATILE RAM!\n");
     printf("YOU MUST USE SOME OTHER METHOD TO OBTAIN NETWORK CONFIGURATION\n");


### PR DESCRIPTION
A few key modifications

- Moved the libbsd network task start to the rtems_init.c
- Changed the setBootConfigFromNVRAM function argument to the older version (void), and use global variables to pass the variables to rtems_init
- Updated the newly introduced global variable names, so that they all starts from nvram_
- Updated a few other variable and function names so that all variables with "bsdnet" are only used in Legacy Network.
- Changed the splitRtemsBootCmdline function so it works for both Legacy and Libbsd.
- Recover the block of code for legacy network to previous versions, to minimize the chance to break this part of the code, if people still want to use them. 

The default boot method is to use dhcp, unless the environment dhcp_ena is set to no.

As for the environment variable names, it will first check the mvme2500-style name (like "ipaddr"), and if failed, it will then try the names used in the legacy network. If you were using the legacy style environment names like "mot-/dev/enet0-cipa", you don't need to change anything. 

